### PR TITLE
hlte-common: Enforce presence of msm8974-common BoardConfigCommon.mk

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # inherit from common msm8974
--include device/samsung/msm8974-common/BoardConfigCommon.mk
+include device/samsung/msm8974-common/BoardConfigCommon.mk
 
 COMMON_PATH := device/samsung/hlte-common
 


### PR DESCRIPTION
* This should always be present in the source tree

Change-Id: I898d721ac66f83c1bc5b11bebddec53e2a4483ea